### PR TITLE
Only add line spacing when there are 1 or more lines.

### DIFF
--- a/RDHCollectionViewGridLayout/RDHCollectionViewGridLayout.m
+++ b/RDHCollectionViewGridLayout/RDHCollectionViewGridLayout.m
@@ -118,7 +118,9 @@ static CGFloat const RDHLineExtensionDefault = 0;
         case UICollectionViewScrollDirectionHorizontal:
             size.width = self.numberOfLines * self.calculatedItemSize.width;
             // Add spacings
-            size.width += (self.numberOfLines - 1) * self.lineSpacing;
+            if (self.numberOfLines > 0) {
+                size.width += (self.numberOfLines - 1) * self.lineSpacing;
+            }
             size.height = [self constrainedCollectionViewDimension];
             break;
             
@@ -126,7 +128,9 @@ static CGFloat const RDHLineExtensionDefault = 0;
             size.width = [self constrainedCollectionViewDimension];
             size.height = self.numberOfLines * self.calculatedItemSize.height;
             // Add spacings
-            size.height += (self.numberOfLines - 1) * self.lineSpacing;
+            if (self.numberOfLines > 0) {
+                size.height += (self.numberOfLines - 1) * self.lineSpacing;
+            }
             break;
     }
     


### PR DESCRIPTION
If `numberOfLines == 0` and `lineSpacing != 0`, the dimensions calculated in `collectionViewContentSize` were incorrect. `numberOfLines - 1` would wrap around to a giant int which was causing `size.height` to become extremely large in my case. The grid layout partially broke down and autolayout complained with this log message:

`This NSLayoutConstraint is being configured with a constant that exceeds internal limits.  A smaller value will be substituted, but this problem should be fixed. Break on void _NSLayoutConstraintNumberExceedsLimit() to debug.  This will be logged only once.  This may break in the future.`

I was wondering if the guard checks should actually be `self.numberOfLines > 1` since line spacing is really only needed if there are 2 or more lines but I didn't want to change any pre-existing behaviour other users may rely on.
